### PR TITLE
Fixed missing 'sync' error

### DIFF
--- a/src/floatingactionbutton/floatingactionbutton-common.ts
+++ b/src/floatingactionbutton/floatingactionbutton-common.ts
@@ -75,13 +75,13 @@ export abstract class FloatingActionButtonBase extends View {
                     //     source.fromResource(resPath).then(imageLoaded);
                     // }
                 } else {
-                    if (sync) {
-                        source.loadFromFile(value);
-                        imageLoaded();
-                    } else {
-                        this.imageSource = null;
-                        source.fromFile(value).then(imageLoaded);
-                    }
+                    // if (sync) {
+                    source.loadFromFile(value);
+                    imageLoaded();
+                    // } else {
+                    //     this.imageSource = null;
+                    //     source.fromFile(value).then(imageLoaded);
+                    // }
                 }
             } else {
                 this.imageSource = null;


### PR DESCRIPTION
I'm unsure what the `sync` variable was doing, but I've followed the current pattern of commenting it out in the `FloatingActionButton` so as to get local images working for the icon.