### PR TITLE
Fix angular AOT compilation

### DIFF
--- a/packages/nativescript-material-activityindicator/package.json
+++ b/packages/nativescript-material-activityindicator/package.json
@@ -7,6 +7,8 @@
     "scripts": {
         "tsc-win": "tsc && copy ..\\..\\src\\activityindicator\\activityindicator.d.ts .\\",
         "tsc": "tsc && cp ../../src/activityindicator/activityindicator.d.ts ./",
+        "ngc-win": "ngc",
+        "ngc": "node --max-old-space-size=8192 ../../node_modules/.bin/ngc",
         "clean": "../../node_modules/.bin/rimraf ./*.d.ts ./*.js ./*.js.map"
     },
     "nativescript": {

--- a/packages/nativescript-material-bottomsheet/package.json
+++ b/packages/nativescript-material-bottomsheet/package.json
@@ -7,6 +7,8 @@
     "scripts": {
         "tsc-win": "tsc && copy ..\\..\\src\\bottomsheet\\bottomsheet.d.ts .\\",
         "tsc": "tsc && cp ../../src/bottomsheet/bottomsheet.d.ts ./",
+        "ngc-win": "ngc",
+        "ngc": "node --max-old-space-size=8192 ../../node_modules/.bin/ngc",
         "clean": "../../node_modules/.bin/rimraf ./*.d.ts ./*.js ./*.js.map"
     },
     "nativescript": {

--- a/packages/nativescript-material-button/package.json
+++ b/packages/nativescript-material-button/package.json
@@ -7,6 +7,8 @@
     "scripts": {
         "tsc-win": "tsc && copy ..\\..\\src\\button\\button.d.ts .\\",
         "tsc": "tsc && cp ../../src/button/button.d.ts ./",
+        "ngc-win": "ngc",
+        "ngc": "node --max-old-space-size=8192 ../../node_modules/.bin/ngc",
         "clean": "../../node_modules/.bin/rimraf ./*.d.ts ./*.js ./*.js.map"
     },
     "nativescript": {

--- a/packages/nativescript-material-cardview/package.json
+++ b/packages/nativescript-material-cardview/package.json
@@ -7,6 +7,7 @@
     "scripts": {
         "tsc-win": "tsc && copy ..\\..\\src\\cardview\\cardview.d.ts .\\",
         "tsc": "tsc && cp ../../src/cardview/cardview.d.ts ./",
+        "ngc-win": "ngc",
         "ngc": "node --max-old-space-size=8192 ../../node_modules/.bin/ngc",
         "clean": "../../node_modules/.bin/rimraf ./*.d.ts ./*.js ./*.js.map"
     },

--- a/packages/nativescript-material-floatingactionbutton/package.json
+++ b/packages/nativescript-material-floatingactionbutton/package.json
@@ -7,6 +7,8 @@
     "scripts": {
         "tsc-win": "tsc && copy ..\\..\\src\\floatingactionbutton\\floatingactionbutton.d.ts .\\",
         "tsc": "tsc && cp ../../src/floatingactionbutton/floatingactionbutton.d.ts ./",
+        "ngc-win": "ngc",
+        "ngc": "node --max-old-space-size=8192 ../../node_modules/.bin/ngc",
         "clean": "../../node_modules/.bin/rimraf ./*.d.ts ./*.js ./*.js.map"
     },
     "nativescript": {

--- a/packages/nativescript-material-progress/package.json
+++ b/packages/nativescript-material-progress/package.json
@@ -7,6 +7,8 @@
     "scripts": {
         "tsc-win": "tsc && copy ..\\..\\src\\progress\\progress.d.ts .\\",
         "tsc": "tsc && cp ../../src/progress/progress.d.ts ./",
+        "ngc-win": "ngc",
+        "ngc": "node --max-old-space-size=8192 ../../node_modules/.bin/ngc",
         "clean": "../../node_modules/.bin/rimraf ./*.d.ts ./*.js ./*.js.map"
     },
     "nativescript": {

--- a/packages/nativescript-material-ripple/package.json
+++ b/packages/nativescript-material-ripple/package.json
@@ -7,6 +7,8 @@
     "scripts": {
         "tsc-win": "tsc && copy ..\\..\\src\\ripple\\ripple.d.ts .\\",
         "tsc": "tsc && cp ../../src/ripple/ripple.d.ts ./",
+        "ngc-win": "ngc",
+        "ngc": "node --max-old-space-size=8192 ../../node_modules/.bin/ngc",
         "clean": "../../node_modules/.bin/rimraf ./*.d.ts ./*.js ./*.js.map"
     },
     "nativescript": {

--- a/packages/nativescript-material-slider/package.json
+++ b/packages/nativescript-material-slider/package.json
@@ -7,6 +7,8 @@
     "scripts": {
         "tsc-win": "tsc && copy ..\\..\\src\\slider\\slider.d.ts .\\",
         "tsc": "tsc && cp ../../src/slider/slider.d.ts ./",
+        "ngc-win": "ngc",
+        "ngc": "node --max-old-space-size=8192 ../../node_modules/.bin/ngc",
         "clean": "../../node_modules/.bin/rimraf ./*.d.ts ./*.js ./*.js.map"
     },
     "nativescript": {

--- a/packages/nativescript-material-snackbar/package.json
+++ b/packages/nativescript-material-snackbar/package.json
@@ -7,6 +7,8 @@
     "scripts": {
         "tsc-win": "tsc && copy ..\\..\\src\\snackbar\\snackbar.d.ts .\\",
         "tsc": "tsc && cp ../../src/snackbar/snackbar.d.ts ./",
+        "ngc-win": "ngc",
+        "ngc": "node --max-old-space-size=8192 ../../node_modules/.bin/ngc",
         "clean": "../../node_modules/.bin/rimraf ./*.d.ts ./*.js ./*.js.map"
     },
     "nativescript": {

--- a/packages/nativescript-material-textfield/package.json
+++ b/packages/nativescript-material-textfield/package.json
@@ -7,6 +7,8 @@
     "scripts": {
         "tsc-win": "tsc && copy ..\\..\\src\\textfield\\textfield.d.ts .\\",
         "tsc": "tsc && cp ../../src/textfield/textfield.d.ts ./",
+        "ngc-win": "ngc",
+        "ngc": "node --max-old-space-size=8192 ../../node_modules/.bin/ngc",
         "clean": "../../node_modules/.bin/rimraf ./*.d.ts ./*.js ./*.js.map"
     },
     "nativescript": {

--- a/src/bottomsheet/angular/bottomsheet.module.ts
+++ b/src/bottomsheet/angular/bottomsheet.module.ts
@@ -10,13 +10,16 @@ export class NativeScriptMaterialBottomSheetModule {
     private static initialized: boolean = false;
 
     static forRoot(): ModuleWithProviders {
-        if (!this.initialized) {
-            install();
-        }
-        this.initialized = true;
         return {
             ngModule: NativeScriptMaterialBottomSheetModule,
             providers: [BottomSheetService]
         };
+    }
+
+    public constructor() {
+        if (!NativeScriptMaterialBottomSheetModule.initialized) {
+            install();
+            NativeScriptMaterialBottomSheetModule.initialized = true;
+        }
     }
 }

--- a/src/bottomsheet/angular/bottomsheet.service.ts
+++ b/src/bottomsheet/angular/bottomsheet.service.ts
@@ -1,5 +1,5 @@
 import { ComponentFactoryResolver, ComponentRef, Injectable, Injector, Type, ViewContainerRef } from '@angular/core';
-import { DetachedLoader } from 'nativescript-angular';
+import { DetachedLoader } from 'nativescript-angular/common/detached-loader';
 import { AppHostView } from 'nativescript-angular/app-host-view';
 import { once } from 'nativescript-angular/common/utils';
 import { BottomSheetOptions as MaterialBottomSheetOptions } from '../bottomsheet-common';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -49,5 +49,8 @@
     },
     "include": ["src/**/*", "src/**/*.ts", "./references.d.ts", "./src/references.d.ts"],
     "exclude": ["node_modules", "platforms"],
-    "compileOnSave": false
+    "compileOnSave": false,
+    "angularCompilerOptions": { 
+        "skipTemplateCodegen": true
+    }
 }


### PR DESCRIPTION
Currently most modules are not built with AOT. This ensures all packages that have angular components are built as libraries (`skipTemplateCodegen`) with the angular compiler (`ngc`)

This solves my issues with textfield and bottomsheet (the only two I'm currently using)