### PR TITLE
update ng-demo to NS 6.1

### DIFF
--- a/demo-ng/.gitignore
+++ b/demo-ng/.gitignore
@@ -7,6 +7,7 @@ platforms/
 *.js.map
 *.js
 !webpack.config.js
+!app.css
 
 # Logs
 logs

--- a/demo-ng/package.json
+++ b/demo-ng/package.json
@@ -1,50 +1,46 @@
 {
   "nativescript": {
-    "id": "org.nativescript.demong",
-    "tns-android": {
-      "version": "5.4.0"
-    },
-    "tns-ios": {
-      "version": "5.4.1"
-    }
+      "id": "org.nativescript.demong",
+      "tns-android": {
+          "version": "6.1.0"
+      }
   },
   "description": "NativeScript Application",
   "dependencies": {
-    "@angular/animations": "~8.1.1",
-    "@angular/common": "~8.1.1",
-    "@angular/compiler": "~8.1.1",
-    "@angular/core": "~8.1.1",
-    "@angular/forms": "~8.1.1",
-    "@angular/http": "~8.0.0-beta.10",
-    "@angular/platform-browser": "~8.1.1",
-    "@angular/platform-browser-dynamic": "~8.1.1",
-    "@angular/router": "~8.1.1",
-    "nativescript-angular": "~8.0.1",
-    "nativescript-material-activityindicator": "file:../packages/nativescript-material-activityindicator",
-    "nativescript-material-bottomsheet": "file:../packages/nativescript-material-bottomsheet",
-    "nativescript-material-button": "file:../packages/nativescript-material-button",
-    "nativescript-material-cardview": "file:../packages/nativescript-material-cardview",
-    "nativescript-material-core": "file:../packages/nativescript-material-core",
-    "nativescript-material-dialogs": "file:../packages/nativescript-material-dialogs",
-    "nativescript-material-floatingactionbutton": "file:../packages/nativescript-material-floatingactionbutton",
-    "nativescript-material-progress": "file:../packages/nativescript-material-progress",
-    "nativescript-material-ripple": "file:../packages/nativescript-material-ripple",
-    "nativescript-material-slider": "file:../packages/nativescript-material-slider",
-    "nativescript-material-snackbar": "file:../packages/nativescript-material-snackbar",
-    "nativescript-material-textfield": "file:../packages/nativescript-material-textfield",
-    "nativescript-theme-core": "~1.0.6",
-    "reflect-metadata": "~0.1.13",
-    "rxjs": "~6.5.2",
-    "tns-core-modules": "rc",
-    "zone.js": "~0.8.26"
+      "@angular/animations": "~8.2.6",
+      "@angular/common": "~8.2.6",
+      "@angular/compiler": "~8.2.6",
+      "@angular/core": "~8.2.6",
+      "@angular/forms": "~8.2.6",
+      "@angular/http": "~8.0.0-beta.10",
+      "@angular/platform-browser": "~8.2.6",
+      "@angular/platform-browser-dynamic": "~8.2.6",
+      "@angular/router": "~8.2.6",
+      "nativescript-angular": "~8.2.1",
+      "nativescript-material-activityindicator": "file:../packages/nativescript-material-activityindicator",
+      "nativescript-material-bottomsheet": "file:../packages/nativescript-material-bottomsheet",
+      "nativescript-material-button": "file:../packages/nativescript-material-button",
+      "nativescript-material-cardview": "file:../packages/nativescript-material-cardview",
+      "nativescript-material-core": "file:../packages/nativescript-material-core",
+      "nativescript-material-dialogs": "file:../packages/nativescript-material-dialogs",
+      "nativescript-material-floatingactionbutton": "file:../packages/nativescript-material-floatingactionbutton",
+      "nativescript-material-progress": "file:../packages/nativescript-material-progress",
+      "nativescript-material-ripple": "file:../packages/nativescript-material-ripple",
+      "nativescript-material-slider": "file:../packages/nativescript-material-slider",
+      "nativescript-material-snackbar": "file:../packages/nativescript-material-snackbar",
+      "nativescript-material-textfield": "file:../packages/nativescript-material-textfield",
+      "nativescript-theme-core": "~1.0.6",
+      "reflect-metadata": "~0.1.13",
+      "rxjs": "~6.5.3",
+      "tns-core-modules": "~6.1.1",
+      "zone.js": "~0.8.26"
   },
   "devDependencies": {
-    "@angular/cli": "^8.1.1",
-    "@angular/compiler-cli": "~8.1.1",
-    "@ngtools/webpack": "~8.1.1",
-    "nativescript-dev-typescript": "~0.10.0",
-    "nativescript-dev-webpack": "rc",
-    "tns-platform-declarations": "rc"
+      "@angular/cli": "^8.2.6",
+      "@angular/compiler-cli": "~8.2.6",
+      "@ngtools/webpack": "~8.3.4",
+      "nativescript-dev-webpack": "~1.2.0",
+      "tns-platform-declarations": "~6.1.1"
   },
   "gitHead": "8ab7726d1ee9991706069c1359c552e67ee0d1a4",
   "readme": "NativeScript Application"

--- a/demo-ng/src/package.json
+++ b/demo-ng/src/package.json
@@ -1,6 +1,7 @@
 {
   "main": "main.js",
   "android": {
-    "v8Flags": "--expose_gc"
+    "v8Flags": "--expose_gc",
+    "markingMode": "none"
   }
 }

--- a/demo-ng/tsconfig.json
+++ b/demo-ng/tsconfig.json
@@ -5,6 +5,7 @@
         "removeComments": true,
         "declaration": false,
         "noLib": false,
+        "skipLibCheck": true,
         "experimentalDecorators": true,
         "emitDecoratorMetadata": true,
         "noEmitHelpers": true,

--- a/demo-ng/tsconfig.tns.json
+++ b/demo-ng/tsconfig.tns.json
@@ -1,7 +1,7 @@
 {
     "extends": "./tsconfig",
     "compilerOptions": {
-        "module": "es2015",
+        "module": "esNext",
         "moduleResolution": "node"
     }
 }

--- a/demo-ng/webpack.config.js
+++ b/demo-ng/webpack.config.js
@@ -32,24 +32,24 @@ module.exports = env => {
 
     // Default destination inside platforms/<platform>/...
     const dist = resolve(projectRoot, nsWebpack.getAppPath(platform, projectRoot));
-    const appResourcesPlatformDir = platform === "android" ? "Android" : "iOS";
 
     const {
         // The 'appPath' and 'appResourcesPath' values are fetched from
-        // the nsconfig.json configuration file
-        // when bundling with `tns run android|ios --bundle`.
+        // the nsconfig.json configuration file.
         appPath = "src",
         appResourcesPath = "App_Resources",
 
         // You can provide the following flags when running 'tns run android|ios'
         aot, // --env.aot
-        snapshot, // --env.snapshot
+        snapshot, // --env.snapshot,
+        production, // --env.production
         uglify, // --env.uglify
         report, // --env.report
         sourceMap, // --env.sourceMap
         hiddenSourceMap, // --env.hiddenSourceMap
         hmr, // --env.hmr,
         unitTesting, // --env.unitTesting
+        verbose, // --env.verbose
     } = env;
 
     const isAnySourceMapEnabled = !!sourceMap || !!hiddenSourceMap;
@@ -60,8 +60,9 @@ module.exports = env => {
     const entryModule = `${nsWebpack.getEntryModule(appFullPath, platform)}.ts`;
     const entryPath = `.${sep}${entryModule}`;
     const entries = { bundle: entryPath };
-    if (platform === "ios") {
-        entries["tns_modules/tns-core-modules/inspector_modules"] = "inspector_modules.js";
+    const areCoreModulesExternal = Array.isArray(env.externals) && env.externals.some(e => e.indexOf("tns-core-modules") > -1);
+    if (platform === "ios" && !areCoreModulesExternal) {
+        entries["tns_modules/tns-core-modules/inspector_modules"] = "inspector_modules";
     };
 
     const ngCompilerTransformers = [];
@@ -100,8 +101,15 @@ module.exports = env => {
 
     let sourceMapFilename = nsWebpack.getSourceMapFilename(hiddenSourceMap, __dirname, dist);
 
+    const itemsToClean = [`${dist}/**/*`];
+    if (platform === "android") {
+        itemsToClean.push(`${join(projectRoot, "platforms", "android", "app", "src", "main", "assets", "snapshots")}`);
+        itemsToClean.push(`${join(projectRoot, "platforms", "android", "app", "build", "configurations", "nativescript-android-snapshot")}`);
+    }
+
+    nsWebpack.processAppComponents(appComponents, platform);
     const config = {
-        mode: uglify ? "production" : "development",
+        mode: production ? "production" : "development",
         context: appFullPath,
         externals,
         watchOptions: {
@@ -188,7 +196,7 @@ module.exports = env => {
         module: {
             rules: [
                 {
-                    test: nsWebpack.getEntryPathRegExp(appFullPath, entryPath),
+                    include: join(appFullPath, entryPath),
                     use: [
                         // Require all Android app components
                         platform === "android" && {
@@ -204,6 +212,7 @@ module.exports = env => {
                                 unitTesting,
                                 appFullPath,
                                 projectRoot,
+                                ignoredFiles: nsWebpack.getUserDefinedEntries(entries, platform)
                             }
                         },
                     ].filter(loader => !!loader)
@@ -253,27 +262,17 @@ module.exports = env => {
             // Define useful constants like TNS_WEBPACK
             new webpack.DefinePlugin({
                 "global.TNS_WEBPACK": "true",
-                "process": undefined,
+                "process": "global.process",
             }),
             // Remove all files from the out dir.
-            new CleanWebpackPlugin([`${dist}/**/*`]),
+            new CleanWebpackPlugin(itemsToClean, { verbose: !!verbose }),
             // Copy assets to out dir. Add your own globs as needed.
             new CopyWebpackPlugin([
                 { from: { glob: "fonts/**" } },
                 { from: { glob: "**/*.jpg" } },
                 { from: { glob: "**/*.png" } },
             ], { ignore: [`${relative(appPath, appResourcesFullPath)}/**`] }),
-            // Generate a bundle starter script and activate it in package.json
-            new nsWebpack.GenerateBundleStarterPlugin(
-                // Don't include `runtime.js` when creating a snapshot. The plugin
-                // configures the WebPack runtime to be generated inside the snapshot
-                // module and no `runtime.js` module exist.
-                (snapshot ? [] : ["./runtime"])
-                    .concat([
-                        "./vendor",
-                        "./bundle",
-                    ])
-            ),
+            new nsWebpack.GenerateNativeScriptEntryPointsPlugin("bundle"),
             // For instructions on how to set up workers with webpack
             // check out https://github.com/nativescript/worker-loader
             new NativeScriptWorkerPlugin(),
@@ -282,19 +281,6 @@ module.exports = env => {
             new nsWebpack.WatchStateLoggerPlugin(),
         ],
     };
-
-    // Copy the native app resources to the out dir
-    // only if doing a full build (tns run/build) and not previewing (tns preview)
-    if (!externals || externals.length === 0) {
-        config.plugins.push(new CopyWebpackPlugin([
-            {
-                from: `${appResourcesFullPath}/${appResourcesPlatformDir}`,
-                to: `${dist}/App_Resources/${appResourcesPlatformDir}`,
-                context: projectRoot
-            },
-        ]));
-    }
-
 
     if (report) {
         // Generate report files for bundles content


### PR DESCRIPTION
- Updated demo-ng to 6.1
- renamed app.scss to `css` and imported core-theme to apply the theme-core default styles (currently it was not applied so the app had no styling for the theme-core css being used on elements in the demo)
