### PR TITLE
Remove unused module from bottomsheet.ios.ts

### DIFF
--- a/src/bottomsheet/bottomsheet.ios.ts
+++ b/src/bottomsheet/bottomsheet.ios.ts
@@ -1,8 +1,7 @@
 import { ViewWithBottomSheetBase } from './bottomsheet-common';
 import { ios, traceCategories, traceError, traceMessageType, traceWrite, View } from 'tns-core-modules/ui/core/view/view';
 import { ViewBase } from 'tns-core-modules/ui/core/view-base';
-import { ios as iosUtils, layout } from 'tns-core-modules/utils/utils';
-import * as application from 'tns-core-modules/application';
+import { layout } from 'tns-core-modules/utils/utils';
 import { BottomSheetOptions } from './bottomsheet';
 import { fromObject } from 'tns-core-modules/data/observable';
 import { applyMixins } from 'nativescript-material-core/core';


### PR DESCRIPTION
This module `import * as application from 'tns-core-modules/application'` seems never used in bottomsheet.ios.ts, should we remove it?

I removed it and run a test on the iPhone 6 and iPhone X,  without any side effects.

Thanks