### PR TITLE
fix(textview): Editable prop now works

### DIFF
--- a/src/textview/textview.ios.ts
+++ b/src/textview/textview.ios.ts
@@ -111,6 +111,11 @@ class TextViewDelegateImpl extends NSObject implements UITextViewDelegate {
     }
 
     public textViewShouldBeginEditing(textView: UITextView): boolean {
+        const owner = this._owner.get();
+        if (owner) {
+            return owner.editable;
+        }
+
         return true;
     }
 


### PR DESCRIPTION
The editable prop for textview wasn't being honored. I.e. if it was set to false the textview was still editable