### PR TITLE
Angular BottomNavigationBar showBadge fix

### DIFF
--- a/src/bottomnavigationbar/bottomnavigationbar.android.ts
+++ b/src/bottomnavigationbar/bottomnavigationbar.android.ts
@@ -132,7 +132,7 @@ export class BottomNavigationBar extends BottomNavigationBarBase {
         // showBadge method is available in v1.1.0-alpha07 of material components
         // but NS team has the .d.ts for version 1
         // that's why we need to cast the nativeView to any to avoid typing errors
-        const badge = (this.nativeViewProtected as any).showBadge(index);
+        const badge = (this.nativeViewProtected as any).getOrCreateBadge(index);
         if (value) {
             badge.setNumber(value);
         }


### PR DESCRIPTION
The code was trying to call `showBadge` on this: https://developer.android.com/reference/com/google/android/material/bottomnavigation/BottomNavigationView

Overwriting this from outside the library with `getOrCreateBadge` works as expected.