### PR TITLE
fix(bottomsheet): support Angular Ivy compiler

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
         "@commitlint/config-conventional": "^8.3.4",
         "@nativescript/angular":"8.21.0",
         "@nativescript/core":"6.5.1",
+        "@types/node": "14.0.4",
         "husky": "^4.2.3",
         "lerna": "^3.20.2",
         "nativescript-vue": "2.5.1",

--- a/src/bottomsheet/angular/bottomsheet.service.ts
+++ b/src/bottomsheet/angular/bottomsheet.service.ts
@@ -121,7 +121,7 @@ export class BottomSheetService {
         const detachedLoaderFactory = factoryResolver.resolveComponentFactory(DetachedLoader);
         const childInjector = this.createChildInjector(bottomSheetParams, viewContainerRef);
 
-        return viewContainerRef.createComponent(detachedLoaderFactory, -1, childInjector, null);
+        return viewContainerRef.createComponent(detachedLoaderFactory, 0, childInjector, null);
     }
 
     private async loadComponent(type: Type<any>): Promise<ViewWithBottomSheetBase> {


### PR DESCRIPTION
My fix in [here](https://github.com/Akylas/nativescript-material-components/issues/141) worked for using the nativescript-material-components in Ivy, however there was still an issue with the nativescript-material-bottomsheet when Ivy was turned on. It turns out that it was because the index being passed into the Angular viewContainerRef.createComponent should be 0 based (https://angular.io/api/core/ViewContainerRef#insert) and -1 was being passed in here.

I tested this on both iOS and Android with Ivy turned off and on. Everything is working properly.